### PR TITLE
SCT-1147 Implement local user create, update, get

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,6 @@ build-docs:
 test:
 	flake8 src
 	mypy src
-	IDMAP_TEST_FILE=$(TEST_CFG) pytest src --cov src/jgikbase/idmapping
+	IDMAP_TEST_FILE=$(TEST_CFG) pytest --verbose src --cov src/jgikbase/idmapping
 	bandit --recursive src --exclude src/jgikbase/test
 	

--- a/src/jgikbase/idmapping/core/user.py
+++ b/src/jgikbase/idmapping/core/user.py
@@ -1,6 +1,9 @@
 """
 ID Mapping system user classes.
 
+Attributes:
+LOCAL - a local authentication source (see :class:`jgikbase.idmapping.core.user.AuthsourceID`.
+
 """
 from jgikbase.idmapping.util.util import not_none, check_string
 
@@ -14,7 +17,10 @@ class AuthsourceID:
 
     Attributes:
     authsource - the ID of the authentication source.
+    LOCAL - a string designating a local authentication source.
     """
+
+    LOCAL = 'local'
 
     _LEGAL_CHARS = 'a-z'
     _MAX_LEN = 20
@@ -28,6 +34,14 @@ class AuthsourceID:
         '''
         check_string(authsource, 'authsource', self._LEGAL_CHARS, self._MAX_LEN)
         self.authsource = authsource
+
+    def __eq__(self, other):
+        if type(other) is type(self):
+            return other.authsource == self.authsource
+        return False
+
+
+LOCAL = AuthsourceID(AuthsourceID.LOCAL)
 
 
 class User:

--- a/src/jgikbase/idmapping/storage/id_mapping_storage.py
+++ b/src/jgikbase/idmapping/storage/id_mapping_storage.py
@@ -20,10 +20,20 @@ class IDMappingStorage:  # pragma: no cover
     __metaclass__ = _ABCMeta
 
     @_abstractmethod
-    def create_or_update_local_user(self, user: User, token: HashedToken) -> None:
+    def create_local_user(self, user: User, token: HashedToken) -> None:
         """
-        Create or update a user. If the user already exists, the user's token is updated.
+        Create a user. If the user already exists, an exception is thrown.
         Once created, users cannot be removed.
+
+        :param user: the user, which must be in the 'local' user scope.
+        :param token: the user's token after applying a hash function.
+        """
+        raise NotImplementedError()
+
+    @_abstractmethod
+    def update_local_user(self, user: User, token: HashedToken) -> None:
+        """
+        Update an existing user's token.
 
         :param user: the user, which must be in the 'local' user scope.
         :param token: the user's token after applying a hash function.

--- a/src/jgikbase/idmapping/storage/mongo/id_mapping_mongo_storage.py
+++ b/src/jgikbase/idmapping/storage/mongo/id_mapping_mongo_storage.py
@@ -3,13 +3,14 @@ A MongoDB based storage system for ID mapping.
 """
 from jgikbase.idmapping.storage.id_mapping_storage import IDMappingStorage as _IDMappingStorage
 from jgikbase.idmapping.core.tokens import HashedToken
-from jgikbase.idmapping.core.user import User, AuthsourceID
+from jgikbase.idmapping.core.user import User, LOCAL
 from pymongo.database import Database
 from jgikbase.idmapping.util.util import not_none
+from pymongo.errors import DuplicateKeyError, PyMongoError
+import re
 
 # TODO NOW implement remaining methods in superclass
 # TODO NOW implement database schema checking
-# TODO NOW finish tests
 
 # Testing the (many) catch blocks for the general mongo exception is pretty hard, since it
 # appears as though the mongo clients have a heartbeat, so just stopping mongo might trigger
@@ -44,18 +45,68 @@ class IDMappingMongoStorage(_IDMappingStorage):
         self._ensure_indexes()
 
     def _ensure_indexes(self):
-        self.db[_COL_USERS].create_index([(_FLD_AUTHSOURCE, 1), (_FLD_USER, 1)], unique=True)
+        self.db[_COL_USERS].create_index(_FLD_USER, unique=True)
         self.db[_COL_USERS].create_index(_FLD_TOKEN, unique=True)
 
-    def create_or_update_local_user(self, user: User, token: HashedToken) -> None:
+    def create_local_user(self, user: User, token: HashedToken) -> None:
+        self._check_user_inputs(user, token)
+        try:
+            self.db[_COL_USERS].insert_one({_FLD_USER: user.username,
+                                            _FLD_TOKEN: token.token_hash})
+        except DuplicateKeyError as e:
+            coll, index = self._get_duplicate_location(e)
+            if coll == _COL_USERS:
+                if index == _FLD_USER + '_1':
+                    # TODO EXCEP make duplicate user exception
+                    raise ValueError('Duplicate user: ' + user.username)
+                elif index == _FLD_TOKEN + '_1':
+                    # TODO EXCEP make duplicate token exception
+                    raise ValueError('The provided token already exists in the database')
+            # this is impossible to test
+            raise ValueError('Unexpected duplicate key exception')
+        except PyMongoError as e:
+            # TODO EXCEP handle other mongo errors
+            raise e
+
+    # this regex is gross, but matches duplicate key error text across mongo versions 2 & 3 at
+    # least.
+    _DUPLICATE_KEY_REGEX = re.compile('duplicate key error (index|collection): ' +
+                                      '\\w+\\.(\\w+)( index: |\\.\\$)([\\.\\w]+)\\s+')
+
+    def _get_duplicate_location(self, e: DuplicateKeyError):
+        # this is some shit right here, but there doesn't seem to be a better way.
+        match = self._DUPLICATE_KEY_REGEX.search(e.args[0])
+        if match:
+            return match.group(2), match.group(4)
+        else:
+            # the key value may be sensitive (e.g. a token) so remove it
+            # TODO EXCEP change to appropriate exception
+            raise ValueError('unable to parse duplicate key error: ' +
+                             e.args[0].split('dup key')[0])
+
+    def _check_user_inputs(self, user, token):
         not_none(user, 'user')
         not_none(token, 'token')
+        if user.authsource != LOCAL:
+            raise ValueError('Only users from a {} authsource are allowed'
+                             .format(LOCAL.authsource))
+
+    def update_local_user(self, user: User, token: HashedToken) -> None:
+        self._check_user_inputs(user, token)
         try:
-            self.db[_COL_USERS].insert_one({_FLD_AUTHSOURCE: user.authsource.authsource,
-                                            _FLD_USER: user.username,
-                                            _FLD_TOKEN: token.token_hash})
-        except Exception as e:
-            # TODO EXCEP handle duplicate user, token
+            res = self.db[_COL_USERS].update_one({_FLD_USER: user.username},
+                                                 {'$set': {_FLD_TOKEN: token.token_hash}})
+            if res.matched_count != 1:  # don't care if user was updated or not, just found
+                # TODO EXCEP make user not found exception
+                raise ValueError('No such user: ' + user.username)
+        except DuplicateKeyError as e:
+            coll, index = self._get_duplicate_location(e)
+            if coll == _COL_USERS and index == _FLD_TOKEN + '_1':
+                # TODO EXCEP make duplicate token exception
+                raise ValueError('The provided token already exists in the database')
+            # this is impossible to test
+            raise ValueError('Unexpected duplicate key exception')
+        except PyMongoError as e:
             # TODO EXCEP handle other mongo errors
             raise e
 
@@ -63,10 +114,10 @@ class IDMappingMongoStorage(_IDMappingStorage):
         not_none(token, 'token')
         try:
             userdoc = self.db[_COL_USERS].find_one({_FLD_TOKEN: token.token_hash}, {_FLD_TOKEN: 0})
-        except Exception as e:
+        except PyMongoError as e:
             # TODO EXCEP handle other mongo errors
             raise e
 
         if not userdoc:
             raise ValueError('Invalid token')  # TODO EXCEP use specific exception
-        return User(AuthsourceID(userdoc[_FLD_AUTHSOURCE]), userdoc[_FLD_USER])
+        return User(LOCAL, userdoc[_FLD_USER])

--- a/src/jgikbase/idmapping/util/util.py
+++ b/src/jgikbase/idmapping/util/util.py
@@ -38,7 +38,7 @@ def check_string(string: str, name: str, legal_characters: str=None, max_len: in
     :param string: the string to test.
     :param name: the name of the string to be used in error messages.
     :param legal_characters: a regex character class that matches legal characters in the string.
-        Typical examples are a-zA-Z0-9_, a-z, etc.
+        Typical examples are a-zA-Z_0-9, a-z, etc.
     :param max_len: the maximum length of the string.
     '''
     not_none(string, name)

--- a/src/jgikbase/test/idmapping/core/user_test.py
+++ b/src/jgikbase/test/idmapping/core/user_test.py
@@ -1,4 +1,4 @@
-from jgikbase.idmapping.core.user import AuthsourceID, User
+from jgikbase.idmapping.core.user import AuthsourceID, User, LOCAL
 from pytest import fail
 from jgikbase.test.idmapping.test_utils import assert_exception_correct
 
@@ -29,6 +29,14 @@ def fail_authsource_init(source: str, expected: Exception):
         fail('expected exception')
     except Exception as got:
         assert_exception_correct(got, expected)
+
+
+def test_authsource_equals():
+    assert AuthsourceID('foo') == AuthsourceID('foo')
+    assert AuthsourceID('foo') != AuthsourceID('bar')
+    assert AuthsourceID('foo') != LOCAL
+    assert AuthsourceID('local') == LOCAL
+    assert LOCAL == LOCAL
 
 
 def test_user_init_pass():

--- a/src/jgikbase/test/idmapping/storage/mongo/test_id_mapping_mongo_storage.py
+++ b/src/jgikbase/test/idmapping/storage/mongo/test_id_mapping_mongo_storage.py
@@ -2,9 +2,10 @@ from pytest import fail, fixture
 from jgikbase.test.idmapping.mongo_controller import MongoController
 from jgikbase.test.idmapping import test_utils
 from jgikbase.idmapping.storage.mongo.id_mapping_mongo_storage import IDMappingMongoStorage
-from jgikbase.idmapping.core.user import User, AuthsourceID
+from jgikbase.idmapping.core.user import User, AuthsourceID, LOCAL
 from jgikbase.idmapping.core.tokens import HashedToken
 from jgikbase.test.idmapping.test_utils import assert_exception_correct
+from pymongo.errors import DuplicateKeyError
 
 TEST_DB_NAME = 'test_id_mapping'
 
@@ -54,15 +55,127 @@ def test_index_user(idstorage, mongo):
     indexes = mongo.client[TEST_DB_NAME]['users'].index_information()
     v = mongo.index_version
     expected = {'_id_': {'v': v, 'key': [('_id', 1)], 'ns': 'test_id_mapping.users'},
-                'auth_1_user_1': {'v': v, 'unique': True, 'key': [('auth', 1), ('user', 1)],
-                                  'ns': 'test_id_mapping.users'},
+                'user_1': {'v': v, 'unique': True, 'key': [('user', 1)],
+                           'ns': 'test_id_mapping.users'},
                 'hshtkn_1': {'v': v, 'unique': True, 'key': [('hshtkn', 1)],
                              'ns': 'test_id_mapping.users'}}
     assert indexes == expected
 
 
-def test_save_and_get_user(idstorage):
-    idstorage.create_or_update_local_user(User(AuthsourceID('as'), 'foo'), HashedToken('bar'))
+def test_create_update_and_get_user(idstorage):
+    # create
+    idstorage.create_local_user(User(AuthsourceID('local'), 'foo'), HashedToken('bar'))
     u = idstorage.get_user(HashedToken('bar'))
     assert u.username == 'foo'
-    assert u.authsource.authsource == 'as'
+    assert u.authsource == LOCAL
+
+    # update
+    idstorage.update_local_user(User(AuthsourceID('local'), 'foo'), HashedToken('bat'))
+    u = idstorage.get_user(HashedToken('bat'))
+    assert u.username == 'foo'
+    assert u.authsource == LOCAL
+
+    idstorage.update_local_user(User(AuthsourceID('local'), 'foo'), HashedToken('boo'))
+    u = idstorage.get_user(HashedToken('boo'))
+    assert u.username == 'foo'
+    assert u.authsource == LOCAL
+
+    # test different user
+    idstorage.create_local_user(User(AuthsourceID('local'), 'foo1'), HashedToken('baz'))
+    u = idstorage.get_user(HashedToken('baz'))
+    assert u.username == 'foo1'
+    assert u.authsource == LOCAL
+
+
+def test_create_user_fail_input_None(idstorage):
+    t = HashedToken('t')
+    u = User(LOCAL, 'u')
+    fail_create_user(idstorage, None, t, ValueError('user cannot be None'))
+    fail_create_user(idstorage, u, None, ValueError('token cannot be None'))
+
+
+def test_create_user_fail_not_local(idstorage):
+    u = User(AuthsourceID('a'), 'u')
+    t = HashedToken('t')
+    fail_create_user(idstorage, u, t, ValueError('Only users from a local authsource are allowed'))
+
+
+def test_create_user_fail_duplicate_user(idstorage):
+    idstorage.create_local_user(User(LOCAL, 'u'), HashedToken('t'))
+    fail_create_user(idstorage, User(LOCAL, 'u'), HashedToken('t1'),
+                     ValueError('Duplicate user: u'))
+
+
+def test_create_user_fail_duplicate_token(idstorage):
+    idstorage.create_local_user(User(LOCAL, 'u'), HashedToken('t'))
+    fail_create_user(idstorage, User(LOCAL, 'u1'), HashedToken('t'),
+                     ValueError('The provided token already exists in the database'))
+
+
+def fail_create_user(idstorage, user, token, expected):
+    try:
+        idstorage.create_local_user(user, token)
+        fail('expected exception')
+    except Exception as got:
+        assert_exception_correct(got, expected)
+
+
+def test_update_user_fail_input_None(idstorage):
+    t = HashedToken('t')
+    u = User(LOCAL, 'u')
+    fail_update_user(idstorage, None, t, ValueError('user cannot be None'))
+    fail_update_user(idstorage, u, None, ValueError('token cannot be None'))
+
+
+def test_update_user_fail_not_local(idstorage):
+    u = User(AuthsourceID('a'), 'u')
+    t = HashedToken('t')
+    fail_update_user(idstorage, u, t, ValueError('Only users from a local authsource are allowed'))
+
+
+def test_update_user_fail_duplicate_token(idstorage):
+    idstorage.create_local_user(User(LOCAL, 'u'), HashedToken('t'))
+    idstorage.create_local_user(User(LOCAL, 'u1'), HashedToken('t1'))
+    fail_update_user(idstorage, User(LOCAL, 'u1'), HashedToken('t'),
+                     ValueError('The provided token already exists in the database'))
+
+
+def test_update_user_fail_no_such_user(idstorage):
+    idstorage.create_local_user(User(LOCAL, 'u'), HashedToken('t'))
+    fail_update_user(idstorage, User(LOCAL, 'u1'), HashedToken('t1'),
+                     ValueError('No such user: u1'))
+
+
+def fail_update_user(idstorage, user, token, expected):
+    try:
+        idstorage.update_local_user(user, token)
+        fail('expected exception')
+    except Exception as got:
+        assert_exception_correct(got, expected)
+
+
+def test_get_user_fail_input_None(idstorage):
+    fail_get_user(idstorage, None, ValueError('token cannot be None'))
+
+
+def test_get_user_fail_no_such_token(idstorage):
+    idstorage.create_local_user(User(LOCAL, 'u'), HashedToken('t'))
+    fail_get_user(idstorage, HashedToken('t1'), ValueError('Invalid token'))
+
+
+def fail_get_user(idstorage, token, expected):
+    try:
+        idstorage.get_user(token)
+        fail('expected exception')
+    except Exception as got:
+        assert_exception_correct(got, expected)
+
+
+def test_unparseable_duplicate_key_exception(idstorage):
+    # this is a very naughty test reaching into the implementation
+    try:
+        idstorage._get_duplicate_location(DuplicateKeyError('unmatchable dup key foo'))
+        fail('expected exception')
+    except Exception as got:
+        assert_exception_correct(got,
+                                 ValueError('unable to parse duplicate key error: unmatchable '))


### PR DESCRIPTION
Split create_or_update into two methods to reduce possibility of user
error updating a user when they thought they were creating a new one.

Needs an exception heirarchy.