### PR TITLE
SCT-1147 Switch not_none error type to TypeError

### DIFF
--- a/src/jgikbase/idmapping/core/object_id.py
+++ b/src/jgikbase/idmapping/core/object_id.py
@@ -60,8 +60,7 @@ class Namespace:
         :param namespace_id: the ID of the namespace.
         :param is_publicly_mappable: whether the namespace is publicly mappable or not.
         :param authed_users: users that are authorized to administer the namespace.
-        :raises MissingParameterError: if namespace_id is None
-        :raises TypeError: if authed_users contains None
+        :raises TypeError: if namespace_id is None or authed_users contains None
         '''
         not_none(namespace_id, 'namespace_id')
         self.namespace_id = namespace_id

--- a/src/jgikbase/idmapping/core/user.py
+++ b/src/jgikbase/idmapping/core/user.py
@@ -68,6 +68,7 @@ class User:
         :param authsource_id: The authentication source for the user.
         :param username: The name of the user matching the regex ^[a-z][a-z0-9]+$ and no longer
             than 100 characters.
+        :raises TypeError: if the authshource ID is None.
         :raises MissingParameterError: if the user name is None or whitespace only.
         :raises IllegalUsernameError: if the user name does not meet the requirements.
         """

--- a/src/jgikbase/idmapping/core/util.py
+++ b/src/jgikbase/idmapping/core/util.py
@@ -16,10 +16,10 @@ def not_none(obj: object, name: str):
 
     :param obj: the object to check
     :param name: the name of the object to use in error messages.
-    :raises MissingParameterError: if the object is None.
+    :raises TypeError: if the object is None.
     """
     if obj is None:
-        raise MissingParameterError(name)  # may want to rethink this.
+        raise TypeError(name + ' cannot be None')
 
 
 _REGEX_CACHE: _Dict[str, _Pattern] = {}
@@ -40,8 +40,7 @@ def check_string(string: str, name: str, legal_characters: str=None, max_len: in
     :raises MissingParameterError: if the string is None or whitespace only.
     :raises IllegalParameterError: if the string is too long or contains illegal characters.
     '''
-    not_none(string, name)
-    if not string.strip():
+    if not string or not string.strip():
         raise MissingParameterError(name)
     if max_len and len(string) > max_len:
         raise IllegalParameterError('{} {} exceeds maximum length of {}'
@@ -62,8 +61,7 @@ def no_Nones_in_iterable(iterable: Iterable[Any], name: str) -> None:
 
     :param iterable: the iterable to check.
     :param name: the name of the iterable to be used in error messages.
-    :raises MissingParameterError: if the iterable is None.
-    :raises TypeError: if the iterable contains None.
+    :raises TypeError: if the iterable is None or contains None.
     '''
     not_none(iterable, name)
     for item in iterable:

--- a/src/jgikbase/idmapping/storage/id_mapping_storage.py
+++ b/src/jgikbase/idmapping/storage/id_mapping_storage.py
@@ -30,7 +30,7 @@ class IDMappingStorage:  # pragma: no cover
         :param token: the user's token after applying a hash function.
         :raises ValueError: if the token already exists in the database or the user is not a
             local user (e.g. uses the :const:`jgikbase.idmapping.core.user.LOCAL` authsource).
-        :raises MissingParameterError: if any of the arguments are None.
+        :raises TypeError: if any of the arguments are None.
         :raises UserExistsError: if the user already exists.
         :raises IDMappingStorageError: if an unexpected error occurs.
         """
@@ -45,7 +45,7 @@ class IDMappingStorage:  # pragma: no cover
         :param token: the user's token after applying a hash function.
         :raises ValueError: if the token already exists in the database or the user is not a
             local user (e.g. uses the :const:`jgikbase.idmapping.core.user.LOCAL` authsource).
-        :raises MissingParameterError: if any of the arguments are None.
+        :raises TypeError: if any of the arguments are None.
         :raises NoSuchUserError: if the user does not exist.
         :raises IDMappingStorageError: if an unexpected error occurs.
         """
@@ -57,7 +57,7 @@ class IDMappingStorage:  # pragma: no cover
         Get the user, if any, associated with a hashed token.
 
         :param token: the hashed token.
-        :raises MissingParameterError: if the token is None.
+        :raises TypeError: if the token is None.
         :raises InvalidTokenError: if the token does not exist in the storage system.
         :raises IDMappingStorageError: if an unexpected error occurs.
         """
@@ -78,9 +78,8 @@ class IDMappingStorage:  # pragma: no cover
         Create a new namespace. Once created, namespaces cannot be removed.
 
         :param namespace_id: The namespace to create.
-
-        Throws a :class:`jgikbase.idmapping.core.errors.NamespaceExistsError` if the
-        namespace already exists.
+        :raises TypeError: if the namespace ID is None.
+        :raises NamespaceExistsError: if the namespace already exists.
         """
         raise NotImplementedError()
 
@@ -146,8 +145,9 @@ class IDMappingStorage:  # pragma: no cover
         Get a particular namespace.
 
         :param namespace_id: the id of the namespace to get.
+        :raises TypeError: if the namespace ID is None.
+        :raises NoSuchNamespaceError: if the namespace does not exist.
         """
-        # TODO throw no such namespace
         raise NotImplementedError()
 
     @_abstractmethod

--- a/src/jgikbase/idmapping/storage/mongo/id_mapping_mongo_storage.py
+++ b/src/jgikbase/idmapping/storage/mongo/id_mapping_mongo_storage.py
@@ -83,7 +83,7 @@ class IDMappingMongoStorage(_IDMappingStorage):
 
         :param db: the MongoDB database in which to store the mappings and other data.
         :raises StorageInitException: if the storage system could not be initialized properly.
-        :raises MissingParameterError: if the Mongo database is None.
+        :raises TypeError: if the Mongo database is None.
         """
         not_none(db, 'db')
         self._db = db

--- a/src/jgikbase/test/idmapping/core/object_id_test.py
+++ b/src/jgikbase/test/idmapping/core/object_id_test.py
@@ -68,7 +68,7 @@ def test_namespace_init_pass():
 
 def test_namespace_init_fail():
     nsid = NamespaceID('foo')
-    fail_namespace_init(None, None, MissingParameterError('namespace_id'))
+    fail_namespace_init(None, None, TypeError('namespace_id cannot be None'))
     fail_namespace_init(nsid, set([User(LOCAL, 'foo'), None]),
                         TypeError('None item in authed_users'))
 

--- a/src/jgikbase/test/idmapping/core/user_test.py
+++ b/src/jgikbase/test/idmapping/core/user_test.py
@@ -60,7 +60,7 @@ def test_user_init_pass():
 
 def test_user_init_fail():
     as_ = AuthsourceID('bar')
-    fail_user_init(None, 'foo', MissingParameterError('authsource_id'))
+    fail_user_init(None, 'foo', TypeError('authsource_id cannot be None'))
     fail_user_init(as_, None, MissingParameterError('username'))
     fail_user_init(as_, '       \t      \n   ', MissingParameterError('username'))
     fail_user_init(as_, LONG_STR + 'b', IllegalUsernameError(

--- a/src/jgikbase/test/idmapping/core/util_test.py
+++ b/src/jgikbase/test/idmapping/core/util_test.py
@@ -19,7 +19,7 @@ def test_not_none_fail():
         not_none(None, 'my name')
         fail('expected exception')
     except Exception as got:
-        assert_exception_correct(got, MissingParameterError('my name'))
+        assert_exception_correct(got, TypeError('my name cannot be None'))
 
 
 def test_check_string_pass():
@@ -63,7 +63,7 @@ def test_no_Nones_in_iterable_pass():
 
 
 def test_no_Nones_in_iterable_fail():
-    fail_no_Nones_in_iterable(None, 'my name', MissingParameterError('my name'))
+    fail_no_Nones_in_iterable(None, 'my name', TypeError('my name cannot be None'))
     fail_no_Nones_in_iterable(['a', None, 'c'], 'thingy', TypeError('None item in thingy'))
     fail_no_Nones_in_iterable({'a', 'c', None}, 'thingy2', TypeError('None item in thingy2'))
 

--- a/src/jgikbase/test/idmapping/storage/mongo/test_id_mapping_mongo_storage.py
+++ b/src/jgikbase/test/idmapping/storage/mongo/test_id_mapping_mongo_storage.py
@@ -7,7 +7,7 @@ from jgikbase.idmapping.core.tokens import HashedToken
 from jgikbase.test.idmapping.test_utils import assert_exception_correct
 from pymongo.errors import DuplicateKeyError
 from jgikbase.idmapping.core.errors import NoSuchUserError, UserExistsError, InvalidTokenError,\
-    MissingParameterError, NamespaceExistsError, NoSuchNamespaceError
+    NamespaceExistsError, NoSuchNamespaceError
 from jgikbase.idmapping.storage.errors import IDMappingStorageError, StorageInitException
 import re
 from jgikbase.idmapping.core.object_id import NamespaceID, Namespace
@@ -40,7 +40,7 @@ def test_fail_startup():
         IDMappingMongoStorage(None)
         fail('expected exception')
     except Exception as got:
-        assert_exception_correct(got, MissingParameterError('db'))
+        assert_exception_correct(got, TypeError('db cannot be None'))
 
 # The following tests ensure that all indexes are created correctly. The collection names
 # are tested so that if a new collection is added the test will fail without altering
@@ -173,8 +173,8 @@ def test_create_update_and_get_user(idstorage):
 def test_create_user_fail_input_None(idstorage):
     t = HashedToken('t')
     u = User(LOCAL, 'u')
-    fail_create_user(idstorage, None, t, MissingParameterError('user'))
-    fail_create_user(idstorage, u, None, MissingParameterError('token'))
+    fail_create_user(idstorage, None, t, TypeError('user cannot be None'))
+    fail_create_user(idstorage, u, None, TypeError('token cannot be None'))
 
 
 def test_create_user_fail_not_local(idstorage):
@@ -205,8 +205,8 @@ def fail_create_user(idstorage, user, token, expected):
 def test_update_user_fail_input_None(idstorage):
     t = HashedToken('t')
     u = User(LOCAL, 'u')
-    fail_update_user(idstorage, None, t, MissingParameterError('user'))
-    fail_update_user(idstorage, u, None, MissingParameterError('token'))
+    fail_update_user(idstorage, None, t, TypeError('user cannot be None'))
+    fail_update_user(idstorage, u, None, TypeError('token cannot be None'))
 
 
 def test_update_user_fail_not_local(idstorage):
@@ -237,7 +237,7 @@ def fail_update_user(idstorage, user, token, expected):
 
 
 def test_get_user_fail_input_None(idstorage):
-    fail_get_user(idstorage, None, MissingParameterError('token'))
+    fail_get_user(idstorage, None, TypeError('token cannot be None'))
 
 
 def test_get_user_fail_no_such_token(idstorage):
@@ -291,7 +291,7 @@ def test_create_and_get_namespace(idstorage):
 
 
 def test_create_namespace_fail_input_None(idstorage):
-    fail_create_namespace(idstorage, None, MissingParameterError('namespace_id'))
+    fail_create_namespace(idstorage, None, TypeError('namespace_id cannot be None'))
 
 
 def test_create_namespace_fail_namespace_exists(idstorage):
@@ -309,7 +309,7 @@ def fail_create_namespace(idstorage, namespace_id, expected):
 
 
 def test_get_namespace_fail_input_None(idstorage):
-    fail_get_namespace(idstorage, None, MissingParameterError('namespace_id'))
+    fail_get_namespace(idstorage, None, TypeError('namespace_id cannot be None'))
 
 
 def test_get_namespace_fail_no_such_namespace(idstorage):


### PR DESCRIPTION
The IDMapping error hierarchy is meant to represent user error - e.g.
missing or incorrect input, requests for data that doesn't exist, etc.

It doesn't make sense that a programmer passing in None where an object
is expected throws an exception in that hierarchy - programming errors
like that should just use standard python exceptions.