### PR TITLE
SCT-1221 Make Username class

### DIFF
--- a/design/design.md
+++ b/design/design.md
@@ -107,7 +107,7 @@ system.
 
 `[Auth source]` defines the source of authentication information and currently exists to
 provide for the possibility of alternative authentication sources in the future. In the first
-iteration of the service the only authentication source will be `Local`.
+iteration of the service the only authentication source will be `local`.
 
 #### List namespaces
 

--- a/src/jgikbase/idmapping/core/user.py
+++ b/src/jgikbase/idmapping/core/user.py
@@ -48,6 +48,39 @@ A local authentication source (see :class:`jgikbase.idmapping.core.user.Authsour
 """
 
 
+class Username:
+    """
+    The name of a user.
+
+    :ivar name: the username.
+    """
+
+    def __init__(self, username: str) -> None:
+        """
+        Create a new user name.
+
+        :param username: The name of the user matching the regex ^[a-z][a-z0-9]+$ and no longer
+            than 100 characters.
+        :raises MissingParameterError: if the user name is None or whitespace only.
+        :raises IllegalUsernameError: if the user name does not meet the requirements.
+        """
+        try:
+            check_string(username, 'username', 'a-z0-9', 100)
+        except IllegalParameterError as e:
+            raise IllegalUsernameError(e.message) from e
+        if not username[0].isalpha():
+            raise IllegalUsernameError('username {} must start with a letter'.format(username))
+        self.name = username
+
+    def __eq__(self, other):
+        if type(other) is type(self):
+            return other.name == self.name
+        return False
+
+    def __hash__(self):
+        return hash((self.name,))
+
+
 class User:
     """
     A user for the ID mapping system. Consists of a authentication source and a user name.
@@ -58,27 +91,16 @@ class User:
     :ivar username: the user name.
     """
 
-    _LEGAL_CHARS = 'a-z0-9'
-    _MAX_LEN = 100
-
-    def __init__(self, authsource_id: AuthsourceID, username: str) -> None:
+    def __init__(self, authsource_id: AuthsourceID, username: Username) -> None:
         """
         Create a new user.
 
         :param authsource_id: The authentication source for the user.
-        :param username: The name of the user matching the regex ^[a-z][a-z0-9]+$ and no longer
-            than 100 characters.
-        :raises TypeError: if the authsource ID is None.
-        :raises MissingParameterError: if the user name is None or whitespace only.
-        :raises IllegalUsernameError: if the user name does not meet the requirements.
+        :param username: The name of the user.
+        :raises TypeError: if any of the arguments are None.
         """
         not_none(authsource_id, 'authsource_id')
-        try:
-            check_string(username, 'username', self._LEGAL_CHARS, self._MAX_LEN)
-        except IllegalParameterError as e:
-            raise IllegalUsernameError(e.message) from e
-        if not username[0].isalpha():
-            raise IllegalUsernameError('username {} must start with a letter'.format(username))
+        not_none(username, 'username')
         self.authsource_id = authsource_id
         self.username = username
 

--- a/src/jgikbase/idmapping/storage/id_mapping_storage.py
+++ b/src/jgikbase/idmapping/storage/id_mapping_storage.py
@@ -6,7 +6,7 @@ Interface for a storage system for ID mappings.
 from abc import abstractmethod as _abstractmethod  # pragma: no cover
 from abc import ABCMeta as _ABCMeta  # pragma: no cover
 from jgikbase.idmapping.core.object_id import NamespaceID  # pragma: no cover
-from jgikbase.idmapping.core.user import User  # pragma: no cover
+from jgikbase.idmapping.core.user import User, Username  # pragma: no cover
 from jgikbase.idmapping.core.tokens import HashedToken  # pragma: no cover
 from jgikbase.idmapping.core.object_id import Namespace  # pragma: no cover
 from typing import Iterable, Set, Tuple  # pragma: no cover
@@ -20,16 +20,15 @@ class IDMappingStorage:  # pragma: no cover
     __metaclass__ = _ABCMeta
 
     @_abstractmethod
-    def create_local_user(self, user: User, token: HashedToken) -> None:
+    def create_local_user(self, user: Username, token: HashedToken) -> None:
         """
         Create a user.
         Once created, users cannot be removed. The client programmer is responsible for
         ensuring that the token provided does not already exist in the database.
 
-        :param user: the user, which must be in the 'local' user scope.
+        :param user: the user.
         :param token: the user's token after applying a hash function.
-        :raises ValueError: if the token already exists in the database or the user is not a
-            local user (e.g. uses the :const:`jgikbase.idmapping.core.user.LOCAL` authsource).
+        :raises ValueError: if the token already exists in the database.
         :raises TypeError: if any of the arguments are None.
         :raises UserExistsError: if the user already exists.
         :raises IDMappingStorageError: if an unexpected error occurs.
@@ -37,14 +36,13 @@ class IDMappingStorage:  # pragma: no cover
         raise NotImplementedError()
 
     @_abstractmethod
-    def update_local_user(self, user: User, token: HashedToken) -> None:
+    def update_local_user(self, user: Username, token: HashedToken) -> None:
         """
         Update an existing user's token.
 
-        :param user: the user, which must be in the 'local' user scope.
+        :param user: the user.
         :param token: the user's token after applying a hash function.
-        :raises ValueError: if the token already exists in the database or the user is not a
-            local user (e.g. uses the :const:`jgikbase.idmapping.core.user.LOCAL` authsource).
+        :raises ValueError: if the token already exists in the database.
         :raises TypeError: if any of the arguments are None.
         :raises NoSuchUserError: if the user does not exist.
         :raises IDMappingStorageError: if an unexpected error occurs.
@@ -52,7 +50,7 @@ class IDMappingStorage:  # pragma: no cover
         raise NotImplementedError()
 
     @_abstractmethod
-    def get_user(self, token: HashedToken) -> User:
+    def get_user(self, token: HashedToken) -> Username:
         """
         Get the user, if any, associated with a hashed token.
 
@@ -64,7 +62,7 @@ class IDMappingStorage:  # pragma: no cover
         raise NotImplementedError()
 
     @_abstractmethod
-    def get_users(self) -> Set[User]:
+    def get_users(self) -> Set[Username]:
         """
         Get all the users in the system.
 


### PR DESCRIPTION
It's become clear that forcing an AuthsourceID to always be associated
with a username is stupid.