### PR TITLE
Update design doc

### DIFF
--- a/design/design.md
+++ b/design/design.md
@@ -20,10 +20,10 @@ reused. There are other ID mapping services available but they're source specifi
 
 ## Definitions
 
-* NID - Namespaced ID. A combination of an ID and the namespace it resides in. For example
+* OID - Object ID. A combination of an ID and the namespace it resides in. For example
   (`NCBI Refseq`, `GCF_001598195.1`).
-* PNID - Primary Namespaced ID. This is used to determine who can create and delete a mapping (see
-  below).
+* AOID - Administrative Object ID. This is used to determine who can create and delete a
+  mapping (see below).
 * DAL - Data Abstraction Layer.
 * CLI - Command Line Interface.
 * CSL - Comma Separated List.
@@ -32,17 +32,17 @@ reused. There are other ID mapping services available but they're source specifi
 
 ### Mappings
 
-* A mapping is a tuple of (NID 1, NID 2). One of the NIDs is designated as the PNID by the 
+* A mapping is a tuple of (OID 1, OID 2). One of the OIDs is designated as the AOID by the 
   creator of the mapping (see below).
 * All mappings are publicly readable.
-* It is possible that an NID may map to multiple data in another namespace, so
-  it is expected there may exist multiple tuples containing a particular NID.
+* It is possible that an OID may map to multiple data in another namespace, so
+  it is expected there may exist multiple tuples containing a particular OID.
 * Therefore, the only uniqueness constraint in the system is that each tuple is unique - e.g.
   there are no duplicate records.
-  * Note that there may be 2 copies of a particular tuple - one with the PNID in one namespace,
-    and the other with the PNID in the other namespace.
-* The service must allow ID lookups based on either NID of the tuple.
-* The service must return all NIDs associated with the lookup NID unless filters are specified.
+  * Note that there may be 2 copies of a particular tuple - one with the AOID in one namespace,
+    and the other with the AOID in the other namespace.
+* The service must allow ID lookups based on either OID of the tuple.
+* The service must return all OIDs associated with the lookup OID unless filters are specified.
   * The service must allow filtering results by namespace.
 * Mappings may be deleted.
 
@@ -50,7 +50,7 @@ reused. There are other ID mapping services available but they're source specifi
 
 * All namespaces are publicly readable.
 * Once created, a namespace may not be deleted.
-* Every namespace has one or more administrators.
+* Every namespace has zero or more administrators.
 * A namespace may be publicly mappable. At creation a namespace is not publicly mappable but
   this property may be changed by namespace administrators at will.
 * It is expected that fewer than 1000 namespaces exist in the system, although there is no hard
@@ -59,12 +59,12 @@ reused. There are other ID mapping services available but they're source specifi
 ### Creating and deleting mappings
 * To create a mapping including a namespace that is not publicly mappable, a user must be an
   administrator of that namespace.
-* When creating a mapping, the user must specify which NID is the PNID, and the user must be
-  an administrator for the namespace in the NID.
-* To delete a mapping, the user must be an administrator of the namespace in which the PNID
+* When creating a mapping, the user must specify which OID is the AOID, and the user must be
+  an administrator for the namespace in the OID.
+* To delete a mapping, the user must be an administrator of the namespace in which the AOID
   exists.
 
-Less abstractly, the PNID can be thought of as the user's 'home' namespace, and the other NID
+Less abstractly, the AOID can be thought of as the user's 'home' namespace, and the other OID
 as the 'target' namespace. Typically the target will be a public repository of data, like NCBI,
 and the home will be a system associated with the user, like KBase. The user would often have
 administration rights on the home system, but not on the target, but the target would typically
@@ -73,8 +73,11 @@ system.
 
 ### Administration
 
-* One or more general administrators can create namespaces and add and
-  remove namespace administrators. The general administrators do not have any other privileges for
+* One or more super administrators can add users to the system, generate new tokens for those users,
+  and designate those users as system administrators.
+
+* One or more system administrators can create namespaces and add and
+  remove namespace administrators. The system administrators do not have any other privileges for
   the namespaces, but can always add themselves to a namespace.
 
 ## Design
@@ -83,17 +86,16 @@ system.
   * Try to avoid MIME encoding if at all possible
 * Mappings are stored in MongoDB (with a DAL so alternative storage systems can be swapped in
   via implementing the DAL interface)
-* Administration of namespace creation and administrator assignment is done via a CLI that
+* Administration of user creation and administrator assignment is done via a CLI that
   interfaces with the DAL directly
   * Practically this means anyone with MongoDB credentials for and network access to the database
-    is a general administrator
-  * The CLI allows for creating user accounts associated with a token which can be provided to
-    the user out of band. The token is hashed and stored in the database. Any token expiration
+    is a super administrator
+  * The CLI allows for creating local user accounts associated with a token which can be provided
+    to the user out of band. The token is hashed and stored in the database. Any token expiration
     policies are handled manually via the CLI. A user account is an arbitrary name matching the
     regex `$[a-z][a-z0-9]+^` and an associated token.
-  * The CLI allows for associating user accounts to namespaces in a many-to-many relationship.
-  * The CLI allows for listing all users in the system.
-  * The CLI allows for listing all users that can administrate a namespace.
+  * The CLI allows for making a local user a system administrator or removing that ability.
+  * The CLI allows for listing all local users in the system and their administrative ability.
 
 ### Constraints
 
@@ -109,32 +111,80 @@ system.
 provide for the possibility of alternative authentication sources in the future. In the first
 iteration of the service the only authentication source will be `local`.
 
+#### Create a namespace
+
+Requires the user to be a system administrator.
+
+```
+HEADERS:
+Authorization: [Auth source] <token>
+
+PUT /api/v1/namespace/<namespace>
+```
+
+POST is also accepted.
+
+#### Add a user to a namespace
+
+Requires the user to be a system administrator.
+
+```
+HEADERS:
+Authorization: [Auth source] <token>
+
+PUT /api/v1/namespace/<namespace>/user/<authsource>/<username>
+```
+
+#### Remove a user from a namespace
+
+Requires the user to be a system administrator.
+
+```
+HEADERS:
+Authorization: [Auth source] <token>
+
+DELETE /api/v1/namespace/<namespace>/user/<authsource>/<username>
+```
+
+#### Alter namespace
+
+Requires the user to be namespace administrator.
+
+```
+HEADERS:
+Authorization: [Auth source] <token>
+
+PUT /api/v1/namespace/<namespace>/set/?publicly_mappable=<true or false>
+```
+
+
+#### Show namespace
+
+```
+HEADERS (optional):
+Authorization: [Auth source] <token>
+
+GET /api/v1/namespace/<namespace>
+
+RETURNS:
+{"namespace": <namespace>,
+ "publicly_mappable": <boolean>,
+ "users": [<authsource>/<username>, ...]
+ }
+```
+
+The `users` field is only present if the `Authorization` header is supplied and the user is
+a namespace or general administrator.
+
 #### List namespaces
 
 ```
 GET /api/v1/namespace/
 
 RETURNS:
-[{"namespace": <namespace1>,
-  "publicly_mappable": <boolean1>
-  },
-  ...
-  {"namespace": <namespaceN>,
-  "publicly_mappable": <booleanN>
-  }
- }
-]
-```
-
-#### Show namespace
-
-```
-GET /api/v1/namespace/<namespace>
-
-RETURNS:
-{"namespace": <namespace>,
- "publicly_mappable": <boolean>
- }
+{"publicly_mappable": [<namespace>, ...],
+ "privately_mappable": [<namespace>, ...]
+}
 ```
 
 #### Create a mapping
@@ -143,15 +193,17 @@ RETURNS:
 HEADERS:
 Authorization: [Auth source] <token>
 
-PUT /api/v1/namespace/<primary namespace>/map/<primary ID>/<namespace>/<ID>
+PUT /api/v1/mapping/<administrative namespace>/<administrative ID>/<namespace>/<ID>
 ```
+
+Any unusual characters, but especially slashes, in the IDs must be url-escaped.
 
 POST is also accepted, although not strictly correct.
 
 #### List mappings
 
 ```
-GET /api/v1/namespace/<namespace>/map/<ID>/[?namespace_filter=<namespace CSL>]
+GET /api/v1/mapping/<namespace>/<ID>/[?namespace_filter=<namespace CSL>]
 
 RETURNS:
 [{"namespace": <namespace1>,
@@ -167,23 +219,18 @@ RETURNS:
 ]
 ```
 
+Any unusual characters, but especially slashes, in the IDs must be url-escaped.
+
 #### Delete a mapping
 
 ```
 HEADERS:
 Authorization: [Auth source] <token>
 
-DELETE /api/v1/namespace/<primary namespace>/map/<primary ID>/<namespace>/<ID>
+DELETE /api/v1/mapping/<administrative namespace>/<administrative ID>/<namespace>/<ID>
 ```
 
-#### Alter namespace
-
-```
-HEADERS:
-Authorization: [Auth source] <token>
-
-PUT /api/v1/namespace/<namespace>/set/?publicly_mappable=<true or false>
-```
+Any unusual characters, but especially slashes, in the IDs must be url-escaped.
 
 ## Future work
 

--- a/design/design.md
+++ b/design/design.md
@@ -219,7 +219,7 @@ RETURNS:
 ]
 ```
 
-Any unusual characters, but especially slashes, in the IDs must be url-escaped.
+Any unusual characters, but especially slashes, in the ID must be url-escaped.
 
 #### Delete a mapping
 

--- a/design/design.md
+++ b/design/design.md
@@ -44,12 +44,6 @@ reused. There are other ID mapping services available but they're source specifi
 * The service must allow ID lookups based on either NID of the tuple.
 * The service must return all NIDs associated with the lookup NID unless filters are specified.
   * The service must allow filtering results by namespace.
-* Arbitrary key-value metadata, not to exceed 1KB serialized as a JSON map,
-  may be attached to each NID in a tuple upon creation of the tuple. This may be useful for
-  providing information about the targets of the NID.
-  * For example, NCBI IDs map to both a Genome and Assembly object in KBase, and the metadata
-   may be used by an application to select which object to retrieve.
-  * This metadata is not searchable.
 * Mappings may be deleted.
 
 ### Namespaces
@@ -113,7 +107,7 @@ system.
 
 `[Auth source]` defines the source of authentication information and currently exists to
 provide for the possibility of alternative authentication sources in the future. In the first
-iteration of the service the only authentication source will be `Local`.
+iteration of the service the only authentication source will be `local`.
 
 #### List namespaces
 
@@ -150,25 +144,9 @@ HEADERS:
 Authorization: [Auth source] <token>
 
 PUT /api/v1/namespace/<primary namespace>/map/<primary ID>/<namespace>/<ID>
-{"pnid_meta": {"key1": "value1",
-               ...
-               "keyN": "valueN"},
- "nid_meta": {"key", "value"}
- }
- 
-RETURNS:
-{"pnid": {"namespace": <primary namespace>,
-          "id": <primary ID>,
-          "meta": {...}
-          },
- "nid": {"namespace": <namespace>,
-           "id": <ID>,
-           "meta": {...}
-           }
- }
 ```
 
-Both meta keys, as well as the PUT body in its entirety, are optional.
+POST is also accepted, although not strictly correct.
 
 #### List mappings
 
@@ -178,13 +156,11 @@ GET /api/v1/namespace/<namespace>/map/<ID>/[?namespace_filter=<namespace CSL>]
 RETURNS:
 [{"namespace": <namespace1>,
   "id: <id1>,
-  "meta": {...},
   "is_primary": <boolean1>
   },
   ...
  {"namespace": <namespaceN>,
   "id: <idN>,
-  "meta": {...},
   "is_primary": <booleanN>
   }
  } 
@@ -207,15 +183,9 @@ HEADERS:
 Authorization: [Auth source] <token>
 
 PUT /api/v1/namespace/<namespace>/set/?publicly_mappable=<true or false>
-
-RETURNS:
-{"namespace": <namespace>,
- "publicly_mappable": <boolean>
- }
 ```
 
 ## Future work
 
 * Bulk mapping creation and search endpoints.
 * Provide administrator access via outside authentication systems, such as KBase and JGI auth.
-


### PR DESCRIPTION
* change Namespaced ID to Object ID
  * per Jay's comments re confusion between namespace ID and namespaced ID
* Change Primary ID to Administrative ID. Primary/secondary IDs (and other options, like source/target) imply a directionality to the ID tuple that doesn't exist. Administrative ID makes it clear that the distinction is for administrative purposes.
* Move several CLI functions to the API for ease of use.
* Updates the API to simplify the mapping syntax, which was a bit odd.
* Removed mapping metadata per Torben's comments.
* Removed redundant returns.