### PR TITLE
SCT-1251 Move object ID from url to body for create & remove mappings

### DIFF
--- a/deploy.cfg.example
+++ b/deploy.cfg.example
@@ -27,7 +27,8 @@ dont-trust-x-ip-headers=false
 # Defines which authentication sources are active. Other than local authentication, active
 # authentication sources will need further configuration below to tell the service how to build
 # the user lookup instance for the authentication source. If an authentication source is
-# inactive, users from that source will be unable to use the ID mapping service.
+# inactive, users from that source will be unable to use ID mapping service functions that
+# require authentication.
 authentication-enabled=local
 #authentication-enabled=local, kbase
 

--- a/src/jgikbase/idmapping/config.py
+++ b/src/jgikbase/idmapping/config.py
@@ -30,7 +30,7 @@ class KBaseConfig:
     authentication-enabled (optional)
     authentication-admin-enabled (optional)
     keys specific to each authentication source. See the example deploy.cfg file in this repo
-        or the class variables.
+    or the class variables.
     dont-trust-x-ip-headers (optional)
 
     The last key instructs the server to ignore the X-Real-IP and X-Forwarded-For

--- a/src/jgikbase/idmapping/config.py
+++ b/src/jgikbase/idmapping/config.py
@@ -28,6 +28,9 @@ class KBaseConfig:
     mongo-user (optional)
     mongo-pwd (optional)
     authentication-enabled (optional)
+    authentication-admin-enabled (optional)
+    keys specific to each authentication source. See the example deploy.cfg file in this repo
+        or the class variables.
     dont-trust-x-ip-headers (optional)
 
     The last key instructs the server to ignore the X-Real-IP and X-Forwarded-For

--- a/src/jgikbase/idmapping/core/user_lookup.py
+++ b/src/jgikbase/idmapping/core/user_lookup.py
@@ -156,6 +156,7 @@ class LocalUserLookup(UserLookup):
     """
 
     LOCAL = AuthsourceID('local')
+    """ The ID of the authentication source for local users. """
 
     def __init__(self, storage: IDMappingStorage) -> None:
         '''


### PR DESCRIPTION
Flask always decodes %2F -> /, frustratingly, so there's no difference
between 2/3/4 and 2%2F3%2F4 in a url.