### PR TITLE
Don't require a content-type header with curl

### DIFF
--- a/src/jgikbase/test/idmapping/service/mapper_service_test.py
+++ b/src/jgikbase/test/idmapping/service/mapper_service_test.py
@@ -440,8 +440,13 @@ def check_get_namespaces(returned, expected):
 
 def test_create_mapping_put():
     cli, mapper = build_app()
-    resp = cli.put('/api/v1/mapping/ans/ns', headers={'Authorization': 'source tokey'},
-                   json={'aid1': 'id1', 'id2': 'id2'})
+    # this shouldn't pass if request.get_data() isn't called before checking
+    # auth, but it does. If you're actually running a server this will
+    # cause a json parse erro with the get_data() call.
+    resp = cli.put('/api/v1/mapping/ans/ns',
+                   headers={'Authorization': 'source tokey',
+                            'content-type': 'x-www-form-urlencoded'},
+                   data='{"aid1": "id1", "id2": "id2"}')
     check_create_mapping(resp, mapper)
 
 


### PR DESCRIPTION
If you do curl -d, curl sends a form encoded content type.
If you touch the request, even to get headers, flask will parse the body
and make the raw data inaccessible. Hence, even if your server only
accepts json, you always have to specify content type with curl.

doing request.get_data() before touching anything else caches the raw
data.

What's really great is the flask docs
(http://werkzeug.pocoo.org/docs/0.14/wrappers/#werkzeug.wrappers.BaseRequest.get_data)
say not to call get_data() before checking the content length, but
AFAICT getting the content length header will cause the entire body to
be parsed, as request.get_data() is None after checking the auth header
unless you call get_data() *before* parsing the header.

This is quite frustrating.

ADDENDUM: I'm stupid, and you can just call get_data() whenever you need to. I fix this in a
later PR.