### PR TITLE
SCT-1251 Add time and call id to error structure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ build-docs:
 	-rm -r docs
 	-rm -r docsource/internal_apis
 	mkdir -p docs
-	sphinx-apidoc --separate -o docsource/internal_apis src src/jgikbase/test/*
+	sphinx-apidoc --separate -o docsource/internal_apis src src/jgikbase/test/* src/app.py
 	sphinx-build docsource/ docs
 
 test:

--- a/docsource/conf.py
+++ b/docsource/conf.py
@@ -21,7 +21,7 @@ sys.path.insert(0, os.path.abspath('../src'))
 # -- Project information -----------------------------------------------------
 
 project = 'JGI/KBase ID Mapping Service'
-copyright = '2018, JGI / KBase'
+copyright = '2018, JGI / KBase'  # @ReservedAssignment
 author = 'gaprice@lbl.gov'
 
 # The short X.Y version


### PR DESCRIPTION
Will allow users to provide time & callid to sysops so they can look up
errors in logs. call id will allow for determining which log lines
belong to which request.